### PR TITLE
Fix: opening an empty detail screen

### DIFF
--- a/androidApp/src/main/java/com/dipumba/movies/android/MovieApp.kt
+++ b/androidApp/src/main/java/com/dipumba/movies/android/MovieApp.kt
@@ -80,9 +80,9 @@ fun MovieApp() {
             }
 
             composable(Detail.routeWithArgs, arguments = Detail.arguments){
-                val movieId = it.arguments?.getString("movieId") ?: "0"
+                val movieId = it.arguments?.getInt("movieId") ?: 0
                 val detailViewModel: DetailViewModel = koinViewModel(
-                    parameters = { parametersOf(movieId.toInt()) }
+                    parameters = { parametersOf(movieId) }
                 )
 
                 DetailScreen(uiState = detailViewModel.uiState)


### PR DESCRIPTION
## Problem
An empty detail screen opens when you click on MovieListItem

<img src="https://github.com/patrickdip/KMMMovieApp/assets/55449509/ee5ceff1-52b0-48fb-887f-2e6378932bf8" width="250"/>

## Cause
```
2023-05-23 20:00:49.480 17748-17748 Bundle    com.dipumba.movies.android   W  Key movieId expected String but value was a java.lang.Integer.  The default value <null> was returned.
2023-05-23 20:00:49.506 17748-17748 Bundle    com.dipumba.movies.android   W  Attempt to cast generated internal exception:
                                                                              java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String
                                                                                  at android.os.BaseBundle.getString(BaseBundle.java:1167)
                                                                                  at com.dipumba.movies.android.ComposableSingletons$MovieAppKt$lambda-1$1.invoke(MovieApp.kt:83)
                                                                                  at com.dipumba.movies.android.ComposableSingletons$MovieAppKt$lambda-1$1.invoke(MovieApp.kt:82)
```